### PR TITLE
zig: match reference c allocation strategy for matmul

### DIFF
--- a/src/zig/matmul.zig
+++ b/src/zig/matmul.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
 fn mat_alloc(n: u32) [][]f64 {
-	var a: [][]f64 = undefined;
-	a = std.heap.page_allocator.alloc([]f64, n) catch unreachable;
-	for (a) |*row| {
-		row.* = std.heap.page_allocator.alloc(f64, n) catch unreachable;
+        var a = std.heap.page_allocator.alloc([]f64, n) catch unreachable;
+        var storage: []f64 = std.heap.page_allocator.alloc(f64, n * n) catch unreachable;
+	for (a, 0..) |*row, i| {
+		row.* = storage[i * n..][0..n];
 	}
 	return a;
 }


### PR DESCRIPTION
The current zig implementation allocates for each matrix row. This is an okay solution but it doesn't seem to match any of the other solutions I inspected (notably the C reference). This PR changes this to a two allocation strategy, the same as C.

The performance difference is minor, but it is a bit more representative and the strace is a lot cleaner.

## Original

```
 ((27c970de)) $ make
~/local/zig-0.11/zig build-exe -O ReleaseFast matmul.zig
 ((27c970de)) $ time ./matmul
-1.435001666666568e+02

________________________________________________________
Executed in  303.41 millis    fish           external
   usr time  296.31 millis  431.00 micros  295.88 millis
   sys time    6.84 millis  190.00 micros    6.65 millis

 ((27c970de)) $ strace ./matmul &| wc -l
4513
```

## This PR

```
 (zig-matmul-alloc =) $ make
~/local/zig-0.11/zig build-exe -O ReleaseFast matmul.zig
 (zig-matmul-alloc =) $ time ./matmul
-1.435001666666568e+02

________________________________________________________
Executed in  290.61 millis    fish           external
   usr time  279.77 millis    0.00 micros  279.77 millis
   sys time   10.58 millis  603.00 micros    9.98 millis

 (zig-matmul-alloc =) $ strace ./matmul &| wc -l
16
```
