### PR TITLE
rust matmul: static memory allocation using const generics

### DIFF
--- a/src/rust/matmul.rs
+++ b/src/rust/matmul.rs
@@ -1,8 +1,8 @@
-fn matgen(n: usize) -> Vec<Vec<f64>> {
-	let mut a = vec![vec![0f64; n]; n];
-	let tmp = 1.0 / (n as f64) / (n as f64);
-	for i in 0..n {
-		for j in 0..n {
+fn matgen<const N: usize>() -> Box<[[f64; N]; N]> {
+	let mut a = Box::new([[0f64; N]; N]);
+	let tmp = 1.0 / (N as f64) / (N as f64);
+	for i in 0..N {
+		for j in 0..N {
 			let ii = i as i64;
 			let jj = j as i64;
 			a[i][j] = tmp * ((ii - jj) as f64) * ((ii + jj) as f64);
@@ -11,12 +11,12 @@ fn matgen(n: usize) -> Vec<Vec<f64>> {
 	return a;
 }
 
-fn matmul(n: usize, a: Vec<Vec<f64>>, b: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
-	let mut c = vec![vec![0f64; n]; n];
-	for i in 0..n {
-		for k in 0..n {
+fn matmul<const N: usize>(a: &[[f64; N]; N], b: &[[f64; N]; N]) -> Box<[[f64; N]; N]> {
+	let mut c = Box::new([[0f64; N]; N]);
+	for i in 0..N {
+		for k in 0..N {
 			let aik = a[i][k]; // hoisting aik helps performance, but hoisting b[k] doesn't
-			for j in 0..n {
+			for j in 0..N {
 				c[i][j] += aik * b[k][j];
 			}
 		}
@@ -25,9 +25,9 @@ fn matmul(n: usize, a: Vec<Vec<f64>>, b: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
 }
 
 fn main() {
-	let n = 1500;
-	let a = matgen(n);
-	let b = matgen(n);
-	let c = matmul(n, a, b);
-	println!("{}", c[n>>1][n>>1]);
+	const N: usize = 1500;
+	let a = matgen::<N>();
+	let b = matgen::<N>();
+	let c = matmul::<N>(&a, &b);
+	println!("{}", c[N>>1][N>>1]);
 }


### PR DESCRIPTION
`Vec` is dynamically resizable and adds quite a bit of overhead

static allocation brings rust inline with C:
```shell
❯ hyperfine --warmup 1 "rust/matmul_const" "rust/matmul_vec" "c/matmul" # m1 mac
Benchmark 1: rust/matmul_const
  Time (mean ± σ):     550.9 ms ±   3.6 ms    [User: 544.9 ms, System: 5.1 ms]
  Range (min … max):   546.3 ms … 557.1 ms    10 runs

Benchmark 2: rust/matmul_vec
  Time (mean ± σ):      2.505 s ±  0.004 s    [User: 2.496 s, System: 0.008 s]
  Range (min … max):    2.499 s …  2.509 s    10 runs

Benchmark 3: c/matmul
  Time (mean ± σ):     543.9 ms ±   3.4 ms    [User: 535.2 ms, System: 7.2 ms]
  Range (min … max):   538.5 ms … 550.3 ms    10 runs

Summary
  src/c/matmul ran
    1.01 ± 0.01 times faster than src/rust/matmul_const
    4.61 ± 0.03 times faster than src/rust/matmul_vec
```