### PR TITLE
[D] optimize matmul

### DIFF
--- a/src/d/matmul.d
+++ b/src/d/matmul.d
@@ -15,10 +15,12 @@ double[][] matmul(int n, in double[][] a, in double[][] b) {
 		for (int j = 0; j < n; ++j)
 			c[i][j] = 0.0;
 	for (int i = 0; i < n; ++i) {
+		auto ci = c[i];
 		for (int k = 0; k < n; ++k) {
 			auto aik = a[i][k]; // faster this way
+			auto bk = b[k];
 			for (int j = 0; j < n; ++j)
-				c[i][j] += aik * b[k][j];
+				ci[j] += aik * bk[j];
 		}
 	}
 	return c;

--- a/src/d/matmul.d
+++ b/src/d/matmul.d
@@ -9,16 +9,15 @@ double[][] matgen(in int n) {
 	return a;
 }
 
-double[][] matmul(in double[][] a, in double[][] b) {
-	auto m = a.length, n = a[0].length, p = b[0].length;
-	auto c = new double[][](m, p);
-	for (int i = 0; i < m; ++i)
-		for (int j = 0; j < p; ++j)
+double[][] matmul(int n, in double[][] a, in double[][] b) {
+	auto c = new double[][](n, n);
+	for (int i = 0; i < n; ++i)
+		for (int j = 0; j < n; ++j)
 			c[i][j] = 0.0;
-	for (int i = 0; i < m; ++i) {
+	for (int i = 0; i < n; ++i) {
 		for (int k = 0; k < n; ++k) {
 			auto aik = a[i][k]; // faster this way
-			for (int j = 0; j < p; ++j)
+			for (int j = 0; j < n; ++j)
 				c[i][j] += aik * b[k][j];
 		}
 	}
@@ -29,6 +28,6 @@ void main(in string[] args) {
 	int n = 1500;
 	auto a = matgen(n);
 	auto b = matgen(n);
-	auto c = matmul(a, b);
+	auto c = matmul(n, a, b);
 	writeln(c[n / 2][n / 2]);
 }


### PR DESCRIPTION
Tested on Intel i5 10400 CPU, linux kernel: 6.6.8, ldc2: 1.35.0 (DMD v2.105.2, LLVM 16.0.6)

```
$ hyperfine -i --warmup 1 "./matmul_before" "./matmul_after"
Benchmark 1: ./matmul_before
  Time (mean ± σ):      3.578 s ±  0.017 s    [User: 3.564 s, System: 0.008 s]
  Range (min … max):    3.558 s …  3.614 s    10 runs
 
Benchmark 2: ./matmul_after
  Time (mean ± σ):      2.751 s ±  0.027 s    [User: 2.737 s, System: 0.008 s]
  Range (min … max):    2.712 s …  2.787 s    10 runs
 
Summary
  ./matmul_after ran
    1.30 ± 0.01 times faster than ./matmul_before

```

2nd commit even faster

```
$ hyperfine -i --warmup 1 "./matmul_after" "./matmul_after2"
Benchmark 1: ./matmul_after
  Time (mean ± σ):      2.742 s ±  0.024 s    [User: 2.734 s, System: 0.005 s]
  Range (min … max):    2.712 s …  2.786 s    10 runs
 
Benchmark 2: ./matmul_after2
  Time (mean ± σ):      1.502 s ±  0.024 s    [User: 1.493 s, System: 0.006 s]
  Range (min … max):    1.457 s …  1.541 s    10 runs
 
Summary
  ./matmul_after2 ran
    1.83 ± 0.03 times faster than ./matmul_after

```