### PR TITLE
Elide boundschecks for julia nqueens

### DIFF
--- a/src/julia/nqueen.jl
+++ b/src/julia/nqueen.jl
@@ -6,7 +6,7 @@ function nq_solve(n)
 	m = 0
 	y0 = (1<<n) - 1
 	k = 1
-	while k >= 1
+	@inbounds while k >= 1
 		y = (l[k] | c[k] | r[k]) & y0
 		if xor(y, y0) >> a[k] != 0
 			i = a[k]


### PR DESCRIPTION
The C implementation isn't doing any boundschecking for nqueens, so I think it's also fair to remove the boundschecking from the julia code.

Before this change I get
```julia
julia> @btime nq_solve(15)
  3.144 s (4 allocations: 704 bytes)
2279184
```
after this change I get
```julia
julia> @btime nq_solve(15)
  2.664 s (4 allocations: 704 bytes)
2279184
```