### PR TITLE
[Julia] Use integer division in sudoku to match C behavior

### DIFF
--- a/src/julia/sudoku.jl
+++ b/src/julia/sudoku.jl
@@ -7,7 +7,7 @@ function sd_genmat()
 	r = 1
 	for i = 0:8, j = 0:8, k = 0:8
 		C[r,1] = 9 * i + j + 1
-		C[r,2] = (floor(i/3)*3 + floor(j/3)) * 9 + k + 82
+		C[r,2] = (div(i, 3)*3 + div(j, 3)) * 9 + k + 82
 		C[r,3] = 9 * i + k + 163
 		C[r,4] = 9 * j + k + 244
 		r += 1


### PR DESCRIPTION
The current code uses `floor(i / 3)`. With `i::Int`, this promotes to `Float64`, but then needs to be implicitly `convert`ed back to `Int` to get stored in the destination array. To better match the behavior of the C code for which `/` performs integer division rounding toward 0, we can use the integer division function `div` which avoids the intermediate promotion to `Float64` and rounds toward 0 by default.