### PR TITLE
Common Lisp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.dwarf
 *.json
 *.dll
+*.fasl

--- a/src/cl/Makefile
+++ b/src/cl/Makefile
@@ -1,9 +1,15 @@
 LISP ?= sbcl
-EXE=nqueen
+EXE=nqueen matmul
 
 all:$(EXE)
 
 nqueen:nqueen.asd
+	$(LISP) --load $< \
+		--eval "(ql:quickload :$@)" \
+		--eval "(asdf:make :$@)" \
+		--eval "(quit)"
+
+matmul:matmul.asd
 	$(LISP) --load $< \
 		--eval "(ql:quickload :$@)" \
 		--eval "(asdf:make :$@)" \

--- a/src/cl/Makefile
+++ b/src/cl/Makefile
@@ -1,0 +1,13 @@
+LISP ?= sbcl
+EXE=nqueen
+
+all:$(EXE)
+
+nqueen:nqueen.asd
+	$(LISP) --load $< \
+		--eval "(ql:quickload :$@)" \
+		--eval "(asdf:make :$@)" \
+		--eval "(quit)"
+
+clean:
+	rm -f $(EXE)

--- a/src/cl/matmul.asd
+++ b/src/cl/matmul.asd
@@ -1,0 +1,5 @@
+(asdf:defsystem "matmul"
+  :components ((:file "matmul"))
+  :build-operation "program-op"
+  :build-pathname "matmul"
+  :entry-point "MATMUL:MAIN")

--- a/src/cl/matmul.lisp
+++ b/src/cl/matmul.lisp
@@ -1,0 +1,49 @@
+(defpackage :matmul
+  (:use :cl)
+  (:export #:main))
+
+(in-package :matmul)
+
+(declaim (optimize (speed 3) (space 0) (safety 0) (debug 0)
+                   (compilation-speed 0)))
+
+(defun matgen (n)
+  (declare (type (Unsigned-Byte 32) n))
+  (let ((const (/ 1.0
+                  (coerce n 'Double-Float)
+                  (coerce n 'Double-Float)))
+        (res (make-array (list n n)
+                         :element-type 'Double-Float
+                         :initial-element 0d0)))
+    (declare (type Double-Float const))
+    (dotimes (x n res)
+      (dotimes (y n)
+        (setf (aref res x y)
+              (* const
+                 (- x y)
+                 (+ x y)))))))
+
+(defun matmul (n a b)
+  (declare (type (Unsigned-Byte 32) n)
+           (type (Simple-Array Double-Float (* *)) a b))
+  (let ((res (make-array (list n n)
+                         :element-type 'Double-Float
+                         :initial-element 0d0)))
+    (dotimes (i n res)
+      (dotimes (j n)
+        (let ((aij (aref a i j)))
+          (declare (type Double-Float aij))
+          (dotimes (k n)
+            (incf (aref res i k)
+                  (* aij
+                     (aref b j k)))))))))
+
+(defun main nil
+  (let* ((n 1500)
+         (m (ash n -1)))
+    (declare (type (Unsigned-Byte 32) n m))
+    (format t "~F~%"
+            (aref (matmul n
+                          (matgen n)
+                          (matgen n))
+                  m m))))

--- a/src/cl/nqueen.asd
+++ b/src/cl/nqueen.asd
@@ -1,0 +1,5 @@
+(asdf:defsystem "nqueen"
+  :components ((:file "nqueen"))
+  :build-operation "program-op"
+  :build-pathname "nqueen"
+  :entry-point "NQUEEN:MAIN")

--- a/src/cl/nqueen.lisp
+++ b/src/cl/nqueen.lisp
@@ -1,0 +1,82 @@
+(defpackage :nqueen
+  (:use :cl)
+  (:export #:main))
+
+(in-package :nqueen)
+
+(declaim (optimize (speed 3) (space 0) (safety 0) (debug 0)
+                   (compilation-speed 0)))
+
+(defun solve (n)
+  (declare (type (Integer 0 63) n))
+  (let ((a (make-array n
+                       :element-type 'Fixnum
+                       :initial-element -1))
+        (l (make-array n
+                       :element-type 'Fixnum
+                       :initial-element 0))
+        (c (make-array n
+                       :element-type 'Fixnum
+                       :initial-element 0))
+        (r (make-array n
+                       :element-type 'Fixnum
+                       :initial-element 0))
+        (i 0)
+        (k 0)
+        (m 0)
+        (y 0)
+        (y0 (1- (the Fixnum (ash (the Fixnum 1) n))))
+        (z 0))
+    (declare (type (Integer 0 63) i)
+             (type Fixnum k m y y0 z))
+    (tagbody
+     beginning
+       (if (< k 0)
+           (go end)
+           (setf y
+                 (logand (logior (aref l k)
+                                 (aref c k)
+                                 (aref r k))
+                         y0)))
+       (setf i (1+ (aref a k)))
+       (when (= (ash (the Fixnum (logxor y y0))
+                     (the Fixnum (- i)))
+                0)
+         (go backtrack))
+     inc-i
+       (setf z (ash 1 i))
+       (when (and (< i n)
+                  (/= (logand y z)
+                      0))
+         (incf i)
+         (go inc-i))
+       (if (< k (1- n))
+           (progn
+             (setf (aref a k) i)
+             (incf k)
+             (setf (aref l k)
+                   (ash (logior (aref l (1- k))
+                                z)
+                        1))
+             (setf (aref c k)
+                   (logior (aref c (1- k))
+                           z))
+             (setf (aref r k)
+                   (ash (logior (aref r (1- k))
+                                z)
+                        -1)))
+           (progn
+             (incf m)
+             (decf k)))
+       (go beginning)
+     backtrack
+       (setf (aref a k)
+             -1)
+       (decf k)
+       (go beginning)
+     end)
+    m))
+
+(defun main nil
+  (format t "~A~%"
+          (solve 15)))


### PR DESCRIPTION
Fairly simple implementation in Common Lisp. I've only checked SBCL, but Clozure, ECL, and LispWorks should all work. Matmul is frustratingly slow, but I'm not smart enough to make it fast without punting off to Bordeaux-threads or Lparallel. And we're doing no libraries so... slow but steady it is.

Despite being Lisp it's done in a more imperative style, I might try doing an FP version in Scheme one of these days (if that sounds interesting).

The programs can also be timed in the REPL:

```
$ sbcl
* (load "nqueens.lisp")
* (time (main))
```