### PR TITLE
[C#] Bring matmul.cs in line with the matmul implementation of other languages

### DIFF
--- a/src/csharp/matmul.cs
+++ b/src/csharp/matmul.cs
@@ -1,31 +1,37 @@
 class Matmul {
-	public static double[,] matgen(int n) {
-		double[,] a = new double[n,n];
-		double tmp = 1.0 / n / n;
-		for (int i = 0; i < n; ++i)
-			for (int j = 0; j < n; ++j)
-				a[i,j] = tmp * (i - j) * (i + j);
-		return a;
-	}
-	public static double[,] matmul(double[,] a, double[,] b) {
-		int m = a.GetLength(0), n = a.GetLength(1), p = b.GetLength(0);
-		double[,] c = new double[p,n];
-		for (int i = 0; i < m; ++i)
-			for (int k = 0; k < n; ++k) {
-				double t = a[i,k]; // this improves the performance
-				for (int j = 0; j < p; ++j)
-					c[i,j] += t * b[k,j];
-			}
-		return c;
-	}
-	public static void Main(String[] args) {
-		int n = 1500;
-		if (args.GetLength(0) >= 1) n = int.Parse(args[0]);
-		n = n / 2 * 2;
-		double[,] a, b, x;
-		a = Matmul.matgen(n);
-		b = Matmul.matgen(n);
-		x = Matmul.matmul(a, b);
-		Console.WriteLine(x[n/2,n/2]);
-	}
+        public static double[][] matgen(int n) {
+                double[][] a = new double[n][];
+                double tmp = 1.0 / n / n;
+                for (int i = 0; i < n; ++i) {
+                        a[i] = new double[n];
+                        for (int j = 0; j < n; ++j)
+                                a[i][j] = tmp * (i - j) * (i + j);
+                }
+                return a;
+        }
+        public static double[][] matmul(double[][] a, double[][] b) {
+                int m = a.Length, n = a[0].Length, p = b[0].Length;
+                double[][] c = new double[m][];
+		for (int i = 0; i < m; ++i) {
+                        c[i] = new double[n];
+                        double[] ci = c[i]; 
+                        for (int k = 0; k < n; ++k) {
+                                double aik = a[i][k];
+                                double[] bk = b[k];
+                                for (int j = 0; j < p; ++j)
+                                        ci[j] += aik * bk[j];
+                        }
+                }
+                return c;
+        }
+        public static void Main(string[] args) {
+                int n = 1500;
+                if (args.Length >= 1) n = int.Parse(args[0]);
+                n = n / 2 * 2;
+                double[][] a, b, x;
+                a = matgen(n);
+                b = matgen(n);
+                x = matmul(a, b);
+                Console.WriteLine(x[n/2][n/2]);
+        }
 }


### PR DESCRIPTION
The current version of `matmul.cs` does not function the same as the other versions because it uses a multidimensional array instead of an array of arrays.

This is also much slower in C#. So this PR brings a speedup of over 2x. This brings the performance much closer to the java version.

On my machine (Mac Mini M1 16Gb):
Before: **5.458 s** ±  0.023 s
After: **2.112 s** ±  0.015 s