### PR TITLE
swift matmul: avoid unnecessary allocations

### DIFF
--- a/src/swift/matmul.swift
+++ b/src/swift/matmul.swift
@@ -1,20 +1,41 @@
-func matgen(n: Int) -> [[Float64]] {
-	var a: [[Float64]] = Array(repeating: Array(repeating: 0, count: n), count: n)
+struct Matrix {
+	var storage: [Float64]
+	let cols_no: Int
+
+	init(n: Int) {
+		storage = Array(repeating: 0, count: n*n)
+		cols_no = n
+	}
+
+	subscript(_ index: (Int, Int)) -> Float64 {
+		get {
+			let (i, j) = index
+			return self.storage[i * self.cols_no + j]
+		}
+		set(newValue) {
+			let (i, j) = index
+			self.storage[i * self.cols_no + j] = newValue
+		}
+	}
+}
+
+func matgen(n: Int) -> Matrix {
+	var a = Matrix(n: n)
 	let tmp = 1.0 / Float64(n) / Float64(n);
 	for i in 0...n-1 {
 		for j in 0...n-1 {
-			a[i][j] = tmp * Float64(i - j) * Float64(i + j)
+			a[(i, j)] = tmp * Float64(i - j) * Float64(i + j)
 		}
 	}
 	return a
 }
 
-func matmul(n: Int, a: [[Float64]], b: [[Float64]]) -> [[Float64]] {
-	var c: [[Float64]] = Array(repeating: Array(repeating: 0, count: n), count: n)
+func matmul(n: Int, a: Matrix, b: Matrix) -> Matrix {
+	var c = Matrix(n: n)
 	for i in 0...n-1 {
 		for k in 0...n-1 {
 			for j in 0...n-1 {
-				c[i][j] += a[i][k] * b[k][j]
+				c[(i, j)] += a[(i, k)] * b[(k, j)]
 			}
 		}
 	}
@@ -22,7 +43,7 @@ func matmul(n: Int, a: [[Float64]], b: [[Float64]]) -> [[Float64]] {
 }
 
 var n = 1500
-let a = matgen(n:n)
-let b = matgen(n:n)
-let c = matmul(n:n, a:a, b:b)
-print(c[n>>1][n>>1])
+let a = matgen(n: n)
+let b = matgen(n: n)
+let c = matmul(n: n, a: a, b: b)
+print(c[(n>>1, n>>1)])


### PR DESCRIPTION
Those extra allocations slow down the code in and of themselves and later contribute to more array CoW checks during mutation.

In my tests, this gets the duration from over 9 seconds down to 0.6-0.8 seconds.