### PR TITLE
Provide modified versions of ruby's matmul

### DIFF
--- a/src/ruby/matmul.flat_array.rb
+++ b/src/ruby/matmul.flat_array.rb
@@ -1,0 +1,37 @@
+def matgen(n)
+  tmp = 1.0 / n / n
+  return Array.new(n * n) do |i|
+    k = i / n
+    j = i % n
+    tmp * (k - j) * (k + j)
+  end
+end
+
+def matmul(a, ah, aw, b, _bh, bw)
+  c = Array.new(ah * bw, 0)
+  (0...ah).each do |ay|
+    # a-y-offset
+    ayo = ay * aw
+    cyo = ay * bw
+    (0...aw).each do |ax|
+      # a-cell
+      ac = a[ayo + ax]
+      # b-y-offset
+      byo = ax * bw
+      (0...bw).each do |bx|
+        c[cyo + bx] += ac * b[byo + bx]
+      end
+    end
+  end
+  return c
+end
+
+n = 1500
+if ARGV.length >= 1
+  n = ARGV[0].to_i
+end
+n = n / 2 * 2
+a = matgen(n)
+b = matgen(n)
+c = matmul(a, n, n, b, n, n)
+puts c[n/2 * n + n/2]

--- a/src/ruby/matmul.inline.rb
+++ b/src/ruby/matmul.inline.rb
@@ -1,0 +1,36 @@
+def matgen(n)
+  tmp = 1.0 / n / n
+  # initializes the array inline
+  return Array.new(n) do |i|
+    Array.new(n) do |j|
+      tmp * (i - j) * (i + j)
+    end
+  end
+end
+
+def matmul(a, b)
+  m = a.length
+  n = a[0].length
+  p = b[0].length
+  return Array.new(m) do |i|
+    ai = a[i]
+    Array.new(p) do |j|
+      acc = 0
+      (0...n).each do |k|
+        # the column access here is killing it
+        acc += ai[k] * b[k][j]
+      end
+      acc
+    end
+  end
+end
+
+n = 1500
+if ARGV.length >= 1
+  n = ARGV[0].to_i
+end
+n = n / 2 * 2
+a = matgen(n)
+b = matgen(n)
+c = matmul(a, b)
+puts c[n/2][n/2]


### PR DESCRIPTION
In preparation to try a matmul for elixir, I figured I'd try refactoring the ruby matmul first to get a feel for it and managed to squeeze a bit more performance out of the code, the inline version tries to initialize the arrays through a single pass, this can save quite a bit of time as you don't need to do two passes over the array (once to zero all entries and then again to actual set the values).

I expected the flat_array implementation to do better, but it's about the same performance as the regular version, I suspect it might be the extra overhead from integer math or the way ruby allocates arrays internally.

None the less, I provide these as an improvement or alternative takes, the elixir version will be next.