### PR TITLE
[c] improved implementation of nqueen

### DIFF
--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O3
+CFLAGS=-O3 -fwrapv -flto
 EXE=sudoku nqueen matmul bedcov
 
 all:$(EXE)

--- a/src/c/nqueen.c
+++ b/src/c/nqueen.c
@@ -2,23 +2,27 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#define NQ_MAX 31
+#define NQ_MAX 15
 
-int nq_solve(int n) // inspired the 2nd C implementation from Rossetta Code
+static int nq_solve(int n) // inspired the 2nd C implementation from Rossetta Code
 {
-	int k, a[NQ_MAX+1], m = 0;
-	uint32_t l[NQ_MAX+1], c[NQ_MAX+1], r[NQ_MAX+1], y0 = (1U<<n) - 1;
+	int k, a[NQ_MAX], m = 0;
+	const uint32_t y0 = (1U<<n) - 1;
+	uint32_t l[NQ_MAX], c[NQ_MAX], r[NQ_MAX];
 	for (k = 0; k < n; ++k) a[k] = -1, l[k] = c[k] = r[k] = 0;
 	for (k = 0; k >= 0;) {
 		uint32_t y = (l[k] | c[k] | r[k]) & y0; // bit array for possible choices at row k
 		if ((y ^ y0) >> (a[k] + 1)) { // possible to make a choice
-			int i;
-			for (i = a[k] + 1; i < n; ++i) // look for the first choice
-				if ((y & 1<<i) == 0) break;
+			int i = a[k] + 1;
+			while (i < n) {
+				// look for the first choice
+				if ((y & 1 << i) == 0) break;
+				i++;
+			}
 			if (k < n - 1) { // store the choice
-				uint32_t z = 1<<i;
+				uint32_t z = 1U<<i;
 				a[k++] = i;
-				l[k] = (l[k-1]|z)<<1;
+				l[k] = (l[k-1]|z)<<1U;
 				c[k] =  c[k-1]|z;
 				r[k] = (r[k-1]|z)>>1;
 			} else ++m, --k; // solution found
@@ -27,12 +31,9 @@ int nq_solve(int n) // inspired the 2nd C implementation from Rossetta Code
 	return m;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
-	int n = 15, m;
-	if (argc > 1) n = atoi(argv[1]);
-	if (n > NQ_MAX) abort();
-	m = nq_solve(n);
-	printf("%d\n", m);
+	int n = 15;
+	printf("%d\n", nq_solve(n));
 	return 0;
 }


### PR DESCRIPTION
It no longer allocates more memory than needed (like the implementation in other languages) and does not perform additional checks before calling `nq_solve` (like other languages implementations)

Tested on Apple M2 Max, 96gb RAM, macOS 13.4.1 (c) (22F770820d)

Hyperfine:
```
Benchmark 1: ./src/c/nqueen-old
  Time (mean ± σ):      2.462 s ±  0.032 s    [User: 2.425 s, System: 0.035 s]
  Range (min … max):    2.431 s …  2.521 s    10 runs

Benchmark 2: ./src/c/nqueen
  Time (mean ± σ):      2.192 s ±  0.012 s    [User: 2.161 s, System: 0.031 s]
  Range (min … max):    2.182 s …  2.212 s    10 runs

Summary
  './src/c/nqueen' ran
    1.12 ± 0.02 times faster than './src/c/nqueen-old'
```

Comparison with V (current first place):
```
Benchmark 1: ./src/v/nqueen
  Time (mean ± σ):      2.208 s ±  0.009 s    [User: 2.179 s, System: 0.029 s]
  Range (min … max):    2.193 s …  2.224 s    10 runs

Benchmark 2: ./src/c/nqueen
  Time (mean ± σ):      2.185 s ±  0.006 s    [User: 2.158 s, System: 0.025 s]
  Range (min … max):    2.177 s …  2.194 s    10 runs

Summary
  './src/c/nqueen' ran
    1.01 ± 0.00 times faster than './src/v/nqueen'
```