### PR TITLE
swift sudoku: turn Sudoku class into a struct

### DIFF
--- a/src/swift/sudoku.swift
+++ b/src/swift/sudoku.swift
@@ -17,7 +17,7 @@ struct Matrix {
     }
 }
 
-class Sudoku {
+struct Sudoku {
 	var R: Matrix
 	var C: Matrix
 	init() {


### PR DESCRIPTION
Classes in Swift are reference types, while structs are value types. Each time a reference-typed argument is passed into a function, Swift inserts an ARC retain call before the function call and an ARC release call after the function call. This has a huge performance cost.

Calls to methods of a class are implemented as function calls with an implicit self argument, so this applied every time solve() was called from outside the Sudoku class, and every time the Sudoku class methods called other Sudoku class methods.

In my tests, this makes sudoku take ~1.825s.