### PR TITLE
improved performance of Rust implementation of nqueen, added input handling as in other implementation

### DIFF
--- a/src/rust/nqueen.rs
+++ b/src/rust/nqueen.rs
@@ -1,9 +1,8 @@
 pub fn nq_solve(n: usize) -> usize {
-	const MAX_N: usize = 32;
-	let mut a: [i32; MAX_N] = [-1; MAX_N];
-	let mut l: [i32; MAX_N] = [0; MAX_N];
-	let mut c: [i32; MAX_N] = [0; MAX_N];
-	let mut r: [i32; MAX_N] = [0; MAX_N];
+	let mut a: Vec<i32> = vec![-1; n];
+	let mut l: Vec<i32> = vec![0; n];
+	let mut c: Vec<i32> = vec![0; n];
+	let mut r: Vec<i32> = vec![0; n];
 	let mut m = 0;
 	let y0 = (1<<n) - 1;
 	let mut k = 0;
@@ -40,5 +39,9 @@ pub fn nq_solve(n: usize) -> usize {
 }
 
 fn main() {
-	println!("{}", nq_solve(15));
+	let mut n = 15;
+	if std::env::args().len() > 1 {
+		n = std::env::args().nth(1).unwrap().parse().unwrap();
+	}
+	println!("{}", nq_solve(n));
 }


### PR DESCRIPTION
This may seem counterintuitive, but using static arrays that are twice as large imposes more overhead than allocating just the right amount at runtime.

```
Benchmark 1: ./rust/nqueen
  Time (mean ± σ):      2.455 s ±  0.022 s    [User: 2.414 s, System: 0.038 s]
  Range (min … max):    2.418 s …  2.489 s    10 runs

Benchmark 2: ./rust/nqueen-new
  Time (mean ± σ):      2.221 s ±  0.013 s    [User: 2.187 s, System: 0.032 s]
  Range (min … max):    2.205 s …  2.242 s    10 runs

Summary
  './rust/nqueen-new' ran
    1.11 ± 0.01 times faster than './rust/nqueen'
```