### PR TITLE
Julia nqueens: Use native bitshifting

### DIFF
--- a/src/julia/nqueen.jl
+++ b/src/julia/nqueen.jl
@@ -1,3 +1,5 @@
+lshift(x, i) = x << (i & (8*sizeof(x)-1))
+
 function nq_solve(n)
 	T = UInt32
 	a = T[ 0 for i=1:n ]
@@ -11,11 +13,11 @@ function nq_solve(n)
 		y = (l[k] | c[k] | r[k]) & y0
 		if xor(y, y0) >> a[k] != 0
 			i = a[k]
-			while i < n && (y & (1<<i)) != 0
+			while i < n && (y & (lshift(1, i))) != 0
 				i += one(i)
 			end
 			if k < n
-				z = one(T) << i
+				z = lshift(one(T), i)
 				a[k] = i + one(i)
 				k += 1
 				l[k] = (l[k-1] | z) << 1


### PR DESCRIPTION
Julia uses saturating bitshifts which also accepts a negative shift value. However, neither x86 nor ARM assembly supports this. Therefore, Julia's bitshifts do not map directly onto native CPU instructions.
Since Julia unfortunately does not yet provide native bitshifting (issue number 50225 in the Julia repo), we can implement it ourselves.

In contrast, in C, bitshifting by too many bits is undefined behaviour, which allows the compiler to emit the raw CPU instruction.

This change gives a small 8% performance increase.