### PR TITLE
[v] [sudoku] less print calls

### DIFF
--- a/src/v/sudoku.v
+++ b/src/v/sudoku.v
@@ -143,10 +143,7 @@ fn ss_solve(ss &SudokuSolver, s string) int {
 			r := ss.r[cc[j]][cr[j]]
 			out[r / 9] = u8(r % 9) + 49
 		}
-		for c in out { // FIXME: there must be a better way! This costs 0.03 sec
-			print(c - 48)
-		}
-		println('')
+		println(out[..].bytestr())
 		n++
 		i--
 		dir = -1


### PR DESCRIPTION
Hello! I fixed V sudoku about reduce print calls: 'FIXME: there must be a better way! This costs 0.03 sec'

Its around 1%.

➜  v git:(master) ✗ hyperfine './sudoku' './sudoku_old'                                                                                                                    
Benchmark 1: ./sudoku
  Time (mean ± σ):      1.469 s ±  0.008 s    [User: 1.431 s, System: 0.001 s]
  Range (min … max):    1.459 s …  1.489 s    10 runs
 
Benchmark 2: ./sudoku_old
  Time (mean ± σ):      1.488 s ±  0.006 s    [User: 1.448 s, System: 0.001 s]
  Range (min … max):    1.474 s …  1.494 s    10 runs
 
Summary
  ./sudoku ran
    1.01 ± 0.01 times faster than ./sudoku_old


