### PR TITLE
Go's matmul with continuous matrix allocation (as opposed to "ragged tensor")

### DIFF
--- a/src/go/matmul.go
+++ b/src/go/matmul.go
@@ -4,40 +4,50 @@ import (
 	"fmt"
 )
 
-func matgen(n int) [][]float64 {
-	a := make([][]float64, n);
-	tmp := float64(1.0) / float64(n) / float64(n);
-	for i := 0; i < n; i++ {
-		a[i] = make([]float64, n);
-		for j := 0; j < n; j++ {
-			a[i][j] = tmp * float64(i - j) * float64(i + j);
-		}
-	}
-	return a;
+type SqMatrix struct {
+	values []float64
+	dim    int
 }
 
-func matmul(n int, a [][]float64, b [][]float64) [][]float64 {
-	c := make([][]float64, n);
-	for i := 0; i < n; i++ {
-		c[i] = make([]float64, n);
+func New(dim int) *SqMatrix {
+	return &SqMatrix{
+		values: make([]float64, dim*dim),
+		dim:    dim,
 	}
+}
+
+func matgen(n int) *SqMatrix {
+	a := New(n)
+	tmp := float64(1.0) / float64(n) / float64(n)
+	aIdx := 0
 	for i := 0; i < n; i++ {
-		ci := c[i]
-		for k := 0; k < n; k++ {
-			t := a[i][k];
-			bk := b[k]
+		for j := 0; j < n; j++ {
+			a.values[aIdx] = tmp * float64(i-j) * float64(i+j)
+			aIdx++
+		}
+	}
+	return a
+}
+
+func matmul(n int, a, b *SqMatrix) *SqMatrix {
+	c := New(n)
+	for i := 0; i < n; i++ {
+		aRow := a.values[i*n : (i+1)*n]
+		cRow := c.values[i*n : (i+1)*n]
+		for k, aValue := range aRow {
+			bRow := b.values[k*n : (k+1)*n]
 			for j := 0; j < n; j++ {
-				ci[j] += t * bk[j];
+				cRow[j] += aValue * bRow[j]
 			}
 		}
 	}
-	return c;
+	return c
 }
 
 func main() {
-	n := 1500;
-	a := matgen(n);
-	b := matgen(n);
-	c := matmul(n, a, b);
-	fmt.Println(c[n>>1][n>>1]);
+	n := 1500
+	a := matgen(n)
+	b := matgen(n)
+	c := matmul(n, a, b)
+	fmt.Println(c.values[n>>1*n+n>>1])
 }


### PR DESCRIPTION
I quickly looked at the code when I saw a [reddit post](https://www.reddit.com/r/vlang/comments/192gdaf/vlang_places_among_the_highest_in_programming/), and in the Go implementation I noticed a common issue of using slices of slices as matrices (or tensors more generically) --> slices of slices work more as ["ragged tensors"](https://www.tensorflow.org/guide/ragged_tensor), tensors with variable lengths. These are more flexible, but incur in serious cost.

So instead I created a trivial matrix structure (2 fields), simplified the code, and it is almost 2 times as fast -- and I would argue written more naturally (but that is in the eye of the beholder).

Check it out :)
