### PR TITLE
Small cleanup for Ruby benchmarks

### DIFF
--- a/src/ruby/matmul.rb
+++ b/src/ruby/matmul.rb
@@ -2,13 +2,11 @@
 
 def matgen(n)
   tmp = 1.0 / n / n
-  a = Array.new(n) { Array.new(n, 0.0) }
-  for i in 0...n
-    for j in 0...n
-      a[i][j] = tmp * (i - j) * (i + j)
-    end
-  end
-  a
+  Array.new(n) { |i|
+    Array.new(n) { |j|
+      tmp * (i - j) * (i + j)
+    }
+  }
 end
 
 def matmul(a, b)

--- a/src/ruby/sudoku.rb
+++ b/src/ruby/sudoku.rb
@@ -222,7 +222,7 @@ i = 0
 while i < n
   hard20.each do |line|
     sd_solve(mr, mc, line)
-	puts ""
+    puts ""
   end
   i += 1
 end

--- a/src/ruby/sudoku.rb
+++ b/src/ruby/sudoku.rb
@@ -28,7 +28,7 @@ def sd_genmat
   while r2 < 729
     c2 = 0
     while c2 < 4
-      mr[mc[r2][c2]].push(r2)
+      mr[mc[r2][c2]] << r2
       c2 += 1
     end
     r2 += 1


### PR DESCRIPTION
See individual commit messages for details.

Notably:
* Use Array.new's block to directly initialize the matrix
  Average of 5 runs with n=400 on ruby 3.3.0 + YJIT:
  Before: 2248ms
  After:  2174ms