### PR TITLE
replaced assignments to x(:) with x

### DIFF
--- a/src/fortran/nqueen.F90
+++ b/src/fortran/nqueen.F90
@@ -11,10 +11,10 @@ CONTAINS
         INTEGER :: k, i
         m = 0
         y0 = ISHFT(1, n) - 1
-        a(:) = -1
-        l(:) = 0
-        c(:) = 0
-        r(:) = 0
+        a = -1
+        l = 0
+        c = 0
+        r = 0
         k = 0
         DO WHILE (k >= 0)
             y = IAND(y0, IOR(r(k), IOR(l(k), c(k))))


### PR DESCRIPTION
Some compilers optimize assignments to an array x better than to x(:).