### PR TITLE
Add Chapel versions of matmul and nqueen

### DIFF
--- a/src/chapel/Makefile
+++ b/src/chapel/Makefile
@@ -1,0 +1,14 @@
+CHPL=chpl
+CHPLFLAGS=--fast
+EXE=nqueen matmul
+
+all:$(EXE)
+
+matmul:matmul.chpl
+	$(CHPL) $(CHPLFLAGS) -o $@ $<
+
+nqueen:nqueen.chpl
+	$(CHPL) $(CHPLFLAGS) -o $@ $<
+
+clean:
+	rm -f $(EXE)

--- a/src/chapel/matmul.chpl
+++ b/src/chapel/matmul.chpl
@@ -1,0 +1,52 @@
+// Chapel port of the C matmul benchmark
+// See https://chapel-lang.org/
+// Please use the preferred configuration of Chapel when benchmarking;
+// see https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#using-chapel-in-its-preferred-configuration
+
+// While Chapel is a parallel programming language, the matrix multiplication
+// here is not parallel, in order to be comparable with the C version.
+// However, the arrays are initialized in parallel in this version.
+
+// To compile, use
+//
+//   chpl --fast matmul.chpl
+//
+// To run, use
+//
+//   ./matmul
+//
+// or run with a different matrix size, as in:
+//
+//  ./matmul --n=100
+
+
+proc mat_gen(n: int) {
+  const tmp = 1.0 / n / n;
+  const D = {0..<n, 0..<n};
+  const mat:[D] real = forall (i,j) in D do tmp * (i - j) * (i + j); 
+  return mat;
+}
+
+proc mat_mul(n: int, p: int, a:[] real, m: int, b:[] real) {
+  var c:[0..<m, 0..<n] real = 0;
+  // One would expect a parallel matmul in Chapel.
+  // However, this is serial to use the same algorithm.
+  for i in 0..<n {
+    for k in 0..<p {
+      for j in 0..<m {
+        c[i,j] += a[i,k] * b[k,j];
+      }
+    }
+  }
+
+  return c;
+}
+
+config const n = 1500;
+
+proc main() {
+  const a = mat_gen(n);
+  const b = mat_gen(n);
+  const c = mat_mul(n, n, a, n, b);
+  writeln(c[n>>1, n>>1]);
+}

--- a/src/chapel/nqueen-array-32.chpl
+++ b/src/chapel/nqueen-array-32.chpl
@@ -1,0 +1,48 @@
+// this version uses Chapel arrays and uses
+// 32-bit numbers to match the C version
+
+param NQ_MAX = 31;
+
+proc nq_solve(n: int(32)): int {
+  var m: int(32);
+  const y0: uint(32) = 1:uint(32)<<n - 1;
+  var a: [0..<NQ_MAX] int(32);
+  var l,c,r: [0..<NQ_MAX] uint(32);
+  for k in 0..<n {
+    a[k] = -1;
+    // note: l, c, k are already zero-initialized
+  }
+
+  var k:int(32) = 0;
+  while k >= 0 {
+    const y = (l[k] | c[k] | r[k]) & y0; // bit array for possible choices at row k
+    if (y ^ y0) >> (a[k] + 1) != 0 { // possible to make a choice
+      var i = a[k] + 1;
+      while i < n {
+        // look for the first choice
+        if y & (1 << i) == 0 then break;
+        i += 1;
+      }
+      if k < n - 1 { // store the choice
+        const z:uint(32) = 1:uint(32)<<i;
+        a[k] = i; k += 1;
+        l[k] = (l[k-1]|z)<<1;
+        c[k] =  c[k-1]|z;
+        r[k] = (r[k-1]|z)>>1;
+      } else {
+        m += 1; k -= 1; // solution found
+      }
+    } else {
+      a[k] = -1; // no choice; backtrack
+      k -= 1;
+    }
+  }
+  return m;
+}
+
+config const n:int(32) = 15;
+proc main() {
+  if n > NQ_MAX || n <= 0 then halt("bad n value");
+  writeln(nq_solve(n));
+  return 0;
+}

--- a/src/chapel/nqueen-array-64.chpl
+++ b/src/chapel/nqueen-array-64.chpl
@@ -1,0 +1,49 @@
+// This version uses Chapel arrays and 64-bit integers
+// Note: 'int' in Chapel is 64-bits. nqueen-32.chpl is
+// a port that uses the same data types as the C version.
+
+param NQ_MAX = 31;
+
+proc nq_solve(n: int): int {
+  var m: int;
+  const y0: int = 1<<n - 1;
+  var a: [0..<NQ_MAX] int;
+  var l,c,r: [0..<NQ_MAX] int;
+  for k in 0..<n {
+    a[k] = -1;
+    // note: l, c, k are already zero-initialized
+  }
+
+  var k:int = 0;
+  while k >= 0 {
+    const y = (l[k] | c[k] | r[k]) & y0; // bit array for possible choices at row k
+    if (y ^ y0) >> (a[k] + 1) != 0 { // possible to make a choice
+      var i = a[k] + 1;
+      while i < n {
+        // look for the first choice
+        if y & (1 << i) == 0 then break;
+        i += 1;
+      }
+      if k < n - 1 { // store the choice
+        const z:int = 1<<i;
+        a[k] = i; k += 1;
+        l[k] = (l[k-1]|z)<<1;
+        c[k] =  c[k-1]|z;
+        r[k] = (r[k-1]|z)>>1;
+      } else {
+        m += 1; k -= 1; // solution found
+      }
+    } else {
+      a[k] = -1; // no choice; backtrack
+      k -= 1;
+    }
+  }
+  return m;
+}
+
+config const n:int = 15;
+proc main() {
+  if n > NQ_MAX || n <= 0 then halt("bad n value");
+  writeln(nq_solve(n));
+  return 0;
+}

--- a/src/chapel/nqueen-carray-32.chpl
+++ b/src/chapel/nqueen-carray-32.chpl
@@ -1,0 +1,49 @@
+// this version uses c_array rather than regular arrays
+
+use CTypes;
+
+param NQ_MAX = 31;
+
+proc nq_solve(n: int(32)): int {
+  var m: int(32);
+  const y0: uint(32) = 1:uint(32)<<n - 1;
+  var a: c_array(int(32), NQ_MAX);
+  var l,c,r: c_array(uint(32), NQ_MAX);
+  for k in 0..<n {
+    a[k] = -1;
+    // note: l, c, k are already zero-initialized
+  }
+
+  var k:int(32) = 0;
+  while k >= 0 {
+    const y = (l[k] | c[k] | r[k]) & y0; // bit array for possible choices at row k
+    if (y ^ y0) >> (a[k] + 1) != 0 { // possible to make a choice
+      var i = a[k] + 1;
+      while i < n {
+        // look for the first choice
+        if y & (1 << i) == 0 then break;
+        i += 1;
+      }
+      if k < n - 1 { // store the choice
+        const z:uint(32) = 1:uint(32)<<i;
+        a[k] = i; k += 1;
+        l[k] = (l[k-1]|z)<<1;
+        c[k] =  c[k-1]|z;
+        r[k] = (r[k-1]|z)>>1;
+      } else {
+        m += 1; k -= 1; // solution found
+      }
+    } else {
+      a[k] = -1; // no choice; backtrack
+      k -= 1;
+    }
+  }
+  return m;
+}
+
+config const n:int(32) = 15;
+proc main() {
+  if n > NQ_MAX || n <= 0 then halt("bad n value");
+  writeln(nq_solve(n));
+  return 0;
+}

--- a/src/chapel/nqueen.chpl
+++ b/src/chapel/nqueen.chpl
@@ -1,0 +1,68 @@
+// Chapel port of the C nqueen benchmark
+// See https://chapel-lang.org/
+// Please use the preferred configuration of Chapel when benchmarking;
+// see https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#using-chapel-in-its-preferred-configuration
+
+// While Chapel is a parallel programming language, this program is not
+// parallel, in order to be comparable with the C version.
+
+// This version uses Chapel tuples and 32-bit integers.
+
+// To compile, use
+//
+//   chpl --fast nqueen.chpl
+//
+// To run, use
+//
+//   ./nqueen
+//
+// or run with a different board size, as in:
+//
+//  ./nqueen --n=12
+
+
+param NQ_MAX = 31;
+
+proc nq_solve(n: int(32)): int {
+  var m: int(32);
+  const y0: uint(32) = 1:uint(32)<<n - 1;
+  var a: NQ_MAX*int(32);
+  var l,c,r: NQ_MAX*uint(32);
+  for k in 0..<n {
+    a[k] = -1;
+    // note: l, c, k are already zero-initialized
+  }
+
+  var k:int(32) = 0;
+  while k >= 0 {
+    const y = (l[k] | c[k] | r[k]) & y0; // bit array for possible choices at row k
+    if (y ^ y0) >> (a[k] + 1) != 0 { // possible to make a choice
+      var i = a[k] + 1;
+      while i < n {
+        // look for the first choice
+        if y & (1 << i) == 0 then break;
+        i += 1;
+      }
+      if k < n - 1 { // store the choice
+        const z:uint(32) = 1:uint(32)<<i;
+        a[k] = i; k += 1;
+        l[k] = (l[k-1]|z)<<1;
+        c[k] =  c[k-1]|z;
+        r[k] = (r[k-1]|z)>>1;
+      } else {
+        m += 1; k -= 1; // solution found
+      }
+    } else {
+      a[k] = -1; // no choice; backtrack
+      k -= 1;
+    }
+  }
+  return m;
+}
+
+config const n:int(32) = 15;
+proc main() {
+  if n > NQ_MAX || n <= 0 then halt("bad n value");
+  writeln(nq_solve(n));
+  return 0;
+}


### PR DESCRIPTION
This PR adds [Chapel](https://chapel-lang.org/) ports of the C matmul and nqueen benchmarks. These should have competitive performance with the C versions (at least, they do on the systems I have tried them on).

This PR also includes a few alternate versions of nqueen. (These can be removed if necessary before merging).

Please reach out if you have trouble getting these to compile and run on your system.