### PR TITLE
Optimise Julia bedcov for Julia 1.11

### DIFF
--- a/src/julia/bedcov.jl
+++ b/src/julia/bedcov.jl
@@ -29,9 +29,14 @@ function it_index!(a::Memory{Interval{S,T}}) where {S,T}
 	end
 end
 
-function it_overlap!(a::Memory{Interval{S,T}}, st::S, en::S, b::Vector{Interval{S,T}}) where {S,T}
+function it_overlap!(
+	a::Memory{Interval{S,T}},
+	stack::Memory{NTuple{3, Int}},
+	st::S,
+	en::S,
+	b::Vector{Interval{S,T}}
+) where {S,T}
 	empty!(b)
-	stack = Memory{Tuple{Int, Int, Int}}(undef, 64)
 	h = 0
 	while (1<<h <= length(a)) h += 1 end
 	h -= 1
@@ -98,9 +103,10 @@ function main(args)
 	it_index!(a1)
 	tot_cov = 0
 	b = Vector{Interval{Int64,Int64}}()
+	stack = Memory{NTuple{3, Int}}(undef, 64)
 	for k = 1:n
 		st0, en0 = a2[k].st, a2[k].en
-		it_overlap!(a1, st0, en0, b)
+		it_overlap!(a1, stack, st0, en0, b)
 		cov_st, cov_en, cov = 0, 0, 0
 		for i = 1:length(b)
 			st1 = max(b[i].st, st0)

--- a/src/julia/bedcov.jl
+++ b/src/julia/bedcov.jl
@@ -1,3 +1,5 @@
+lsh(a, b) = a << (b & 63)
+
 struct Interval{S,T}
 	data::T
 	st::S
@@ -56,7 +58,7 @@ function it_overlap!(
 			end
 		elseif w == 0
 			stack[stack_len += 1] = (x, h, 1)
-			y = x - (1<<(h-1))
+			y = x - lsh(1, (h-1))
 			if y > length(a) || a[y].max > st
 				stack[stack_len += 1] = (y, h - 1, 0)
 			end

--- a/src/julia/bedcov.jl
+++ b/src/julia/bedcov.jl
@@ -5,7 +5,7 @@ struct Interval{S,T}
 	max::S
 end
 
-function it_index!(a::Vector{Interval{S,T}}) where {S,T}
+function it_index!(a::Memory{Interval{S,T}}) where {S,T}
 	sort!(a, by = x -> x.st)
 	last_i = 1
 	last::S = 0
@@ -29,7 +29,7 @@ function it_index!(a::Vector{Interval{S,T}}) where {S,T}
 	end
 end
 
-function it_overlap!(a::Vector{Interval{S,T}}, st::S, en::S, b::Vector{Interval{S,T}}) where {S,T}
+function it_overlap!(a::Memory{Interval{S,T}}, st::S, en::S, b::Vector{Interval{S,T}}) where {S,T}
 	empty!(b)
 	stack = Memory{Tuple{Int, Int, Int}}(undef, 64)
 	h = 0
@@ -78,13 +78,13 @@ end
 function gen_intv(n, x::Splitmix32, bit_st, bit_len)
 	mask_st  = (1<<bit_st)  - 1
 	mask_len = (1<<bit_len) - 1
-	a = Vector{Interval{Int64,Int64}}()
+	a = Memory{Interval{Int64,Int64}}(undef, n)
 	for i = 1:n
 		s = splitmix32!(x)
 		l = splitmix32!(x)
 		st = s & mask_st
 		en = st + (l & mask_len)
-		push!(a, Interval{Int64,Int64}(i, st, en, 0))
+		a[i] = Interval{Int64,Int64}(i, st, en, 0)
 	end
 	return a, x
 end


### PR DESCRIPTION
This includes a few optimisations for Julia's bedcov. On my computer, it makes the runtime go from 2.2s -> 1.4s.

Here are a list of the optimisations in the PR that could be considered cheating (although I don't)
* Use a manual wrapping shift function instead of the built-in one (like in #48)
* Use the `Memory` type over `Vector` type where possible. This requires bumping Julia from 1.10 to 1.11.
* In the C implementation, the function `iit_overlap` allocates a new stack. C is able to stack-allocate this. However, Julia's ability to similarly stack allocate is brand new, and has not yet made it into a stable release. So meanwhile, this is worked around by allocating the stack once outside the function, then reused.

